### PR TITLE
Fix iOS SDK Compiling (buildapp.yml)

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -81,8 +81,11 @@ jobs:
       - name: Download iOS 15.5 SDK
         if: steps.SDK.outputs.cache-hit != 'true'
         run: |
-          git clone --quiet https://github.com/chrisharper22/sdks.git
-          mv sdks/iPhoneOS15.5.sdk $THEOS/sdks
+          git clone --quiet -n --depth=1 --filter=tree:0 https://github.com/chrisharper22/sdks/
+          cd sdks
+          git sparse-checkout set --no-cone iPhoneOS15.5.sdk
+          git checkout
+          mv *.sdk $THEOS/sdks
         env:
           THEOS: ${{ github.workspace }}/theos
 

--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -81,8 +81,8 @@ jobs:
       - name: Download iOS 15.5 SDK
         if: steps.SDK.outputs.cache-hit != 'true'
         run: |
-          svn checkout -q https://github.com/chrisharper22/sdks/trunk/iPhoneOS15.5.sdk
-          mv *.sdk $THEOS/sdks
+          git clone --quiet https://github.com/chrisharper22/sdks.git
+          mv sdks/iPhoneOS15.5.sdk $THEOS/sdks
         env:
           THEOS: ${{ github.workspace }}/theos
 


### PR DESCRIPTION
This fixes the error below.
```
Run svn checkout -q https://github.com/chrisharper22/sdks/trunk/iPhoneOS15.5.sdk
svn: E170013: Unable to connect to a repository at URL 'https://github.com/chrisharper22/sdks/trunk/iPhoneOS15.5.sdk'
svn: E900002: Subversion support temporarily disabled.

GitHub has temporarily disabled Subversion support as part of a planned brownout
in order to give you advance notice of the upcoming permanent removal of
Subversion support on 2024-01-08.

Please see https://github.blog/2023-01-20-sunsetting-subversion-support/ for details.
Error: Process completed with exit code 1.
```