### PR TITLE
Updated “Hide iSponsorBlock” Option

### DIFF
--- a/Sources/uYouPlus.xm
+++ b/Sources/uYouPlus.xm
@@ -172,6 +172,7 @@ NSBundle *tweakBundle = uYouPlusBundle();
     %orig;
     if (IS_ENABLED(@"hideiSponsorBlockButton_enabled"))
         self.sponsorBlockButton.hidden = YES;
+        self.sponsorBlockButton.frame = CGRectZero;
 }
 %end
 


### PR DESCRIPTION
Hey @therealFoxster I added the line below.
`        self.sponsorBlockButton.frame = CGRectZero;`
this is for the iSponsorBlock button because if you add this line, it will most likely remove the frame which most likely means the gap would be gone. You can test it if you want to 😅